### PR TITLE
Update Microsoft.Web.Xdt to 3.1.0

### DIFF
--- a/source/ConfigTransformationTool/ConfigTransformationTool.csproj
+++ b/source/ConfigTransformationTool/ConfigTransformationTool.csproj
@@ -84,8 +84,8 @@
     <Reference Include="Costura, Version=3.3.3.0, Culture=neutral, PublicKeyToken=9919ef960d84173d, processorArchitecture=MSIL">
       <HintPath>..\packages\Costura.Fody.3.3.3\lib\net40\Costura.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Web.XmlTransform, Version=3.0.0.34420, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Web.Xdt.3.0.0\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
+    <Reference Include="Microsoft.Web.XmlTransform, Version=3.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Web.Xdt.3.1.0\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/source/ConfigTransformationTool/packages.config
+++ b/source/ConfigTransformationTool/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Costura.Fody" version="3.3.3" targetFramework="net40" />
   <package id="Fody" version="4.2.1" targetFramework="net40" developmentDependency="true" />
-  <package id="Microsoft.Web.Xdt" version="3.0.0" targetFramework="net40" />
+  <package id="Microsoft.Web.Xdt" version="3.1.0" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
[This bug](https://github.com/dotnet/xdt/pull/216) was causing ctt to crash when attempting to remove an attribute that does not exist. Updated Microsoft.Web.Xdt package version to 3.1.0 to incorporate the fix for this bug.